### PR TITLE
Version bump to 1.3.9, Adding Version variable

### DIFF
--- a/static/configs/install-linux.sh
+++ b/static/configs/install-linux.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# RustDesk version (manually set by now)
+VERSION="1.3.9"
+
 # Assign a random value to the password variable
 rustdesk_pw=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
 
@@ -63,9 +66,6 @@ if [ ! "${ARCH}" = "x86_64" ] && [ ! "${ARCH}" = "aarch64" ]; then
     echo "Unknown processor architecture"
     exit 1
 fi
-
-# RustDesk version (manually set by now)
-VERSION="1.3.8"
 
 # Install RustDesk
 

--- a/static/configs/install-mac.sh
+++ b/static/configs/install-mac.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# RustDesk version (manually set by now)
+VERSION="1.3.9"
+
 # Assign the value random password to the password variable
 rustdesk_pw=$(openssl rand -hex 4)
 
@@ -24,9 +27,9 @@ mount_point="/Volumes/RustDesk"
 echo "Downloading RustDesk Now"
 
 if [[ $(arch) == 'arm64' ]]; then
-curl -L https://github.com/rustdesk/rustdesk/releases/download/1.3.7/rustdesk-1.3.7-aarch64.dmg --output "$dmg_file"
+curl -L https://github.com/rustdesk/rustdesk/releases/download/"${VERSION}"/rustdesk-"${VERSION}"-aarch64.dmg --output "$dmg_file"
 else
-curl -L https://github.com/rustdesk/rustdesk/releases/download/1.3.7/rustdesk-1.3.7-x86_64.dmg --output "$dmg_file"
+curl -L https://github.com/rustdesk/rustdesk/releases/download/"${VERSION}"/rustdesk-"${VERSION}"-x86_64.dmg --output "$dmg_file"
 fi
 
 # Mount the DMG file to the specified mount point

--- a/static/configs/install.bat
+++ b/static/configs/install.bat
@@ -1,4 +1,6 @@
 @echo off
+# RustDesk version (manually set by now)
+set version="1.3.9"
 
 REM Assign the value random password to the password variable
 setlocal ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
@@ -18,7 +20,7 @@ REM ############################### Please Do Not Edit Below This Line #########
 if not exist C:\Temp\ md C:\Temp\
 cd C:\Temp\
 
-curl -L "https://github.com/rustdesk/rustdesk/releases/download/1.3.7/rustdesk-1.3.7-x86_64.exe" -o rustdesk.exe
+curl -L "https://github.com/rustdesk/rustdesk/releases/download/%version%/rustdesk-%version%-x86_64.exe" -o rustdesk.exe
 
 rustdesk.exe --silent-install
 timeout /t 20

--- a/static/configs/install.bat
+++ b/static/configs/install.bat
@@ -1,5 +1,5 @@
 @echo off
-# RustDesk version (manually set by now)
+REM RustDesk version (manually set by now)
 set version="1.3.9"
 
 REM Assign the value random password to the password variable

--- a/static/configs/install.bat
+++ b/static/configs/install.bat
@@ -1,6 +1,6 @@
 @echo off
 REM RustDesk version (manually set by now)
-set version="1.3.9"
+set version=1.3.9
 
 REM Assign the value random password to the password variable
 setlocal ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION

--- a/static/configs/install.ps1
+++ b/static/configs/install.ps1
@@ -1,5 +1,8 @@
 $ErrorActionPreference= 'silentlycontinue'
 
+# RustDesk version (manually set by now)
+$version = "1.3.9"
+
 # Assign the value random password to the password variable
 $rustdesk_pw=(-join ((65..90) + (97..122) | Get-Random -Count 12 | % {[char]$_}))
 
@@ -18,7 +21,7 @@ if (-Not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
 
 $rdver = ((Get-ItemProperty  "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\RustDesk\").Version)
 
-if($rdver -eq "1.3.7")
+if($rdver -eq $version)
 {
 write-output "RustDesk $rdver is the newest version"
 
@@ -31,7 +34,7 @@ If (!(Test-Path C:\Temp)) {
 
 cd C:\Temp
 
-powershell Invoke-WebRequest "https://github.com/rustdesk/rustdesk/releases/download/1.3.7/rustdesk-1.3.7-x86_64.exe" -Outfile "rustdesk.exe"
+powershell Invoke-WebRequest "https://github.com/rustdesk/rustdesk/releases/download/$version/rustdesk-$version-x86_64.exe" -Outfile "rustdesk.exe"
 Start-Process .\rustdesk.exe --silent-install -wait
 
 $ServiceName = 'Rustdesk'


### PR DESCRIPTION
Bumped version of all config scripts to most recent version [1.3.9](https://github.com/rustdesk/rustdesk/releases) and added version variable at the top of every script to easily update them to the most recent version.

The script [install-linux.sh](https://github.com/infiniteremote/rustdesk-api-server/blob/master/static/configs/install-linux.sh) as well as [install.bat](https://github.com/infiniteremote/rustdesk-api-server/blob/master/static/configs/install.bat) and [install.ps1](https://github.com/infiniteremote/rustdesk-api-server/blob/master/static/configs/install.ps1) have been tested.

The script [install-mac.sh](https://github.com/infiniteremote/rustdesk-api-server/blob/master/static/configs/install-mac.sh) is currently untested but normally should work well.

Updater script will follow to automatically update the client version strings.