### PR TITLE
Bumped rustdesk install scripts to 1.4.3

### DIFF
--- a/static/configs/install-linux.sh
+++ b/static/configs/install-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # RustDesk version (manually set by now)
-VERSION="1.3.9"
+RD_VERSION="1.4.3"
 
 # Assign a random value to the password variable
 rustdesk_pw=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
@@ -71,11 +71,11 @@ fi
 
 echo "Installing RustDesk"
 if [ "${ID}" = "debian" ] || [ "$OS" = "Ubuntu" ] || [ "$OS" = "Debian" ]  || [ "${UPSTREAM_ID}" = "ubuntu" ] || [ "${UPSTREAM_ID}" = "debian" ]; then
-    wget https://github.com/rustdesk/rustdesk/releases/download/"${VERSION}"/rustdesk-"${VERSION}"-"${ARCH}".deb
-    apt-get install -fy ./rustdesk-"${VERSION}"-"${ARCH}".deb > null
+    wget https://github.com/rustdesk/rustdesk/releases/download/"${RD_VERSION}"/rustdesk-"${RD_VERSION}"-"${ARCH}".deb
+    apt-get install -fy ./rustdesk-"${RD_VERSION}"-"${ARCH}".deb > null
 elif [ "$OS" = "CentOS" ] || [ "$OS" = "RedHat" ] || [ "$OS" = "Fedora Linux" ]  || [ "${UPSTREAM_ID}" = "rhel" ] ; then
-    wget https://github.com/rustdesk/rustdesk/releases/download/"${VERSION}"/rustdesk-"${VERSION}"-0."${ARCH}".rpm
-    yum localinstall ./rustdesk-"${VERSION}"-0."${ARCH}".rpm -y > null
+    wget https://github.com/rustdesk/rustdesk/releases/download/"${RD_VERSION}"/rustdesk-"${RD_VERSION}"-0."${ARCH}".rpm
+    yum localinstall ./rustdesk-"${RD_VERSION}"-0."${ARCH}".rpm -y > null
 else
     echo "Unsupported OS"
     # here you could ask the user for permission to try and install anyway

--- a/static/configs/install-mac.sh
+++ b/static/configs/install-mac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # RustDesk version (manually set by now)
-VERSION="1.3.9"
+RD_VERSION="1.4.3"
 
 # Assign the value random password to the password variable
 rustdesk_pw=$(openssl rand -hex 4)
@@ -27,9 +27,9 @@ mount_point="/Volumes/RustDesk"
 echo "Downloading RustDesk Now"
 
 if [[ $(arch) == 'arm64' ]]; then
-curl -L https://github.com/rustdesk/rustdesk/releases/download/"${VERSION}"/rustdesk-"${VERSION}"-aarch64.dmg --output "$dmg_file"
+curl -L https://github.com/rustdesk/rustdesk/releases/download/"${RD_VERSION}"/rustdesk-"${RD_VERSION}"-aarch64.dmg --output "$dmg_file"
 else
-curl -L https://github.com/rustdesk/rustdesk/releases/download/"${VERSION}"/rustdesk-"${VERSION}"-x86_64.dmg --output "$dmg_file"
+curl -L https://github.com/rustdesk/rustdesk/releases/download/"${RD_VERSION}"/rustdesk-"${RD_VERSION}"-x86_64.dmg --output "$dmg_file"
 fi
 
 # Mount the DMG file to the specified mount point

--- a/static/configs/install-mac.sh
+++ b/static/configs/install-mac.sh
@@ -18,7 +18,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 # Specify the path to the rustdesk.dmg file
-dmg_file="/tmp/rustdesk-1.3.7.dmg"
+dmg_file="/tmp/rustdesk-${RD_VERSION}.dmg"
 
 # Specify the mount point for the DMG (temporary directory)
 mount_point="/Volumes/RustDesk"

--- a/static/configs/install.bat
+++ b/static/configs/install.bat
@@ -1,6 +1,6 @@
 @echo off
 REM RustDesk version (manually set by now)
-set version=1.3.9
+set rd_version=1.4.3
 
 REM Assign the value random password to the password variable
 setlocal ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
@@ -20,7 +20,7 @@ REM ############################### Please Do Not Edit Below This Line #########
 if not exist C:\Temp\ md C:\Temp\
 cd C:\Temp\
 
-curl -L "https://github.com/rustdesk/rustdesk/releases/download/%version%/rustdesk-%version%-x86_64.exe" -o rustdesk.exe
+curl -L "https://github.com/rustdesk/rustdesk/releases/download/%rd_version%/rustdesk-%rd_version%-x86_64.exe" -o rustdesk.exe
 
 rustdesk.exe --silent-install
 timeout /t 20

--- a/static/configs/install.ps1
+++ b/static/configs/install.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference= 'silentlycontinue'
 
 # RustDesk version (manually set by now)
-$version = "1.3.9"
+$rd_version = "1.4.3"
 
 # Assign the value random password to the password variable
 $rustdesk_pw=(-join ((65..90) + (97..122) | Get-Random -Count 12 | % {[char]$_}))
@@ -21,7 +21,7 @@ if (-Not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
 
 $rdver = ((Get-ItemProperty  "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\RustDesk\").Version)
 
-if($rdver -eq $version)
+if($rdver -eq $rd_version)
 {
 write-output "RustDesk $rdver is the newest version"
 
@@ -34,7 +34,7 @@ If (!(Test-Path C:\Temp)) {
 
 cd C:\Temp
 
-powershell Invoke-WebRequest "https://github.com/rustdesk/rustdesk/releases/download/$version/rustdesk-$version-x86_64.exe" -Outfile "rustdesk.exe"
+powershell Invoke-WebRequest "https://github.com/rustdesk/rustdesk/releases/download/$rd_version/rustdesk-$rd_version-x86_64.exe" -Outfile "rustdesk.exe"
 Start-Process .\rustdesk.exe --silent-install -wait
 
 $ServiceName = 'Rustdesk'


### PR DESCRIPTION
For the script `install-linux.sh`:
In line 23 the file `/etc/os-release` gets executed and in some cases this sets the env variable `VERSION` which would override the rustdesk version variable resulting in a broken script. So the var name was changed to `RD_VERSION`.

For consistency the name was changed in all other scripts as well.